### PR TITLE
Expand unit test coverage

### DIFF
--- a/emol/cards/tests/test_api.py
+++ b/emol/cards/tests/test_api.py
@@ -1,0 +1,307 @@
+"""Tests for the cards API endpoints."""
+
+from datetime import timedelta
+
+from django.test import TestCase
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from cards.models import (
+    Authorization,
+    Card,
+    Combatant,
+    CombatantAuthorization,
+    Discipline,
+    Marshal,
+    Region,
+    Waiver,
+)
+from cards.utility.time import today
+from sso_user.models import SSOUser
+
+
+class CombatantListAPITestCase(TestCase):
+    """Tests for the combatant list API."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.client = APIClient()
+        self.user = SSOUser.objects.create_superuser(email="admin@example.com")
+        self.combatant = Combatant.objects.create(
+            sca_name="Test Fighter",
+            legal_name="Test Legal",
+            email="test@example.com",
+            accepted_privacy_policy=True,
+        )
+
+    def test_combatant_list_authenticated(self):
+        """Authenticated admin can list combatants."""
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get(reverse("combatant-list-list"))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
+
+
+class CombatantAPITestCase(TestCase):
+    """Tests for the combatant detail API."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.client = APIClient()
+        self.user = SSOUser.objects.create_superuser(email="admin@example.com")
+        self.region, _ = Region.objects.get_or_create(
+            code="ON", defaults={"name": "Ontario", "active": True}
+        )
+        self.combatant = Combatant.objects.create(
+            sca_name="Test Fighter",
+            legal_name="Test Legal",
+            email="test@example.com",
+            accepted_privacy_policy=True,
+            province="ON",
+        )
+
+    def test_combatant_retrieve(self):
+        """Can retrieve a combatant by UUID."""
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get(
+            reverse("combatant-detail", kwargs={"uuid": self.combatant.uuid})
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["sca_name"], "Test Fighter")
+
+    def test_combatant_update(self):
+        """Can update a combatant."""
+        self.client.force_authenticate(user=self.user)
+        response = self.client.patch(
+            reverse("combatant-detail", kwargs={"uuid": self.combatant.uuid}),
+            {"sca_name": "Updated Name"},
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.combatant.refresh_from_db()
+        self.assertEqual(self.combatant.sca_name, "Updated Name")
+
+    def test_combatant_update_invalid_province(self):
+        """Update with invalid province code is rejected."""
+        self.client.force_authenticate(user=self.user)
+        response = self.client.patch(
+            reverse("combatant-detail", kwargs={"uuid": self.combatant.uuid}),
+            {"province": "XX"},
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+
+class CardAPITestCase(TestCase):
+    """Tests for the card API."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.client = APIClient()
+        self.user = SSOUser.objects.create_superuser(email="admin@example.com")
+        self.discipline = Discipline.objects.create(
+            name="Test Combat", slug="test-combat"
+        )
+        self.authorization = Authorization.objects.create(
+            name="Test Auth", slug="test-auth", discipline=self.discipline
+        )
+        self.marshal = Marshal.objects.create(
+            name="Marshal", slug="marshal", discipline=self.discipline
+        )
+        self.combatant = Combatant.objects.create(
+            sca_name="Test Fighter",
+            legal_name="Test Legal",
+            email="test@example.com",
+            accepted_privacy_policy=True,
+        )
+        self.card = Card.objects.create(
+            combatant=self.combatant,
+            discipline=self.discipline,
+            date_issued=today(),
+        )
+        CombatantAuthorization.objects.create(
+            card=self.card, authorization=self.authorization
+        )
+
+    def test_card_retrieve_by_combatant_uuid(self):
+        """Can retrieve cards for a combatant."""
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get(
+            reverse("combatant-cards-detail", kwargs={"uuid": self.combatant.uuid})
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]["discipline"]["name"], "Test Combat")
+
+
+class CardDateAPITestCase(TestCase):
+    """Tests for the card date update API."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.client = APIClient()
+        self.user = SSOUser.objects.create_superuser(email="admin@example.com")
+        self.discipline = Discipline.objects.create(
+            name="Test Combat", slug="test-combat"
+        )
+        self.combatant = Combatant.objects.create(
+            sca_name="Test Fighter",
+            legal_name="Test Legal",
+            email="test@example.com",
+            accepted_privacy_policy=True,
+        )
+
+    def test_card_date_update_creates_card(self):
+        """Card date update creates card if not exists."""
+        self.client.force_authenticate(user=self.user)
+        response = self.client.put(
+            reverse("card-date-detail", kwargs={"pk": 1}),
+            {
+                "uuid": str(self.combatant.uuid),
+                "discipline_slug": "test-combat",
+                "date_issued": str(today()),
+            },
+        )
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertTrue(
+            Card.objects.filter(
+                combatant=self.combatant, discipline=self.discipline
+            ).exists()
+        )
+
+    def test_card_date_update_updates_existing(self):
+        """Card date update modifies existing card."""
+        self.client.force_authenticate(user=self.user)
+        card = Card.objects.create(
+            combatant=self.combatant,
+            discipline=self.discipline,
+            date_issued=today() - timedelta(days=100),
+        )
+        new_date = today()
+
+        response = self.client.put(
+            reverse("card-date-detail", kwargs={"pk": 1}),
+            {
+                "uuid": str(self.combatant.uuid),
+                "discipline_slug": "test-combat",
+                "date_issued": str(new_date),
+            },
+        )
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        card.refresh_from_db()
+        self.assertEqual(card.date_issued, new_date)
+
+
+class WaiverAPITestCase(TestCase):
+    """Tests for the waiver API."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.client = APIClient()
+        self.user = SSOUser.objects.create_superuser(email="admin@example.com")
+        self.combatant = Combatant.objects.create(
+            sca_name="Test Fighter",
+            legal_name="Test Legal",
+            email="test@example.com",
+            accepted_privacy_policy=True,
+        )
+
+    def test_waiver_update_creates_if_not_exists(self):
+        """Waiver update creates waiver if not exists."""
+        self.client.force_authenticate(user=self.user)
+        response = self.client.put(
+            reverse("waiver-detail", kwargs={"uuid": str(self.combatant.uuid)}),
+            {"date_signed": str(today())},
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertTrue(Waiver.objects.filter(combatant=self.combatant).exists())
+
+    def test_waiver_update_modifies_existing(self):
+        """Waiver update modifies existing waiver."""
+        self.client.force_authenticate(user=self.user)
+        waiver = Waiver.objects.create(
+            combatant=self.combatant,
+            date_signed=today() - timedelta(days=100),
+        )
+        new_date = today()
+
+        response = self.client.put(
+            reverse("waiver-detail", kwargs={"uuid": str(self.combatant.uuid)}),
+            {"date_signed": str(new_date)},
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        waiver.refresh_from_db()
+        self.assertEqual(waiver.date_signed, new_date)
+
+    def test_waiver_retrieve(self):
+        """Can retrieve a waiver by combatant UUID."""
+        self.client.force_authenticate(user=self.user)
+        Waiver.objects.create(combatant=self.combatant, date_signed=today())
+
+        response = self.client.get(
+            reverse("waiver-detail", kwargs={"uuid": str(self.combatant.uuid)})
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("date_signed", response.data)
+
+
+class CombatantAuthorizationAPITestCase(TestCase):
+    """Tests for the combatant authorization API."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.client = APIClient()
+        self.user = SSOUser.objects.create_superuser(email="admin@example.com")
+        self.discipline = Discipline.objects.create(
+            name="Test Combat", slug="test-combat"
+        )
+        self.authorization = Authorization.objects.create(
+            name="Test Auth", slug="test-auth", discipline=self.discipline
+        )
+        self.combatant = Combatant.objects.create(
+            sca_name="Test Fighter",
+            legal_name="Test Legal",
+            email="test@example.com",
+            accepted_privacy_policy=True,
+        )
+        self.card = Card.objects.create(
+            combatant=self.combatant,
+            discipline=self.discipline,
+            date_issued=today(),
+        )
+
+    def test_add_authorization(self):
+        """Can add an authorization to a combatant."""
+        self.client.force_authenticate(user=self.user)
+        response = self.client.post(
+            reverse(
+                "combatant-authorization-list",
+                kwargs={"discipline": "test-combat"},
+            ),
+            {
+                "combatant_uuid": str(self.combatant.uuid),
+                "discipline": "test-combat",
+                "authorization": "test-auth",
+            },
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertTrue(
+            CombatantAuthorization.objects.filter(
+                card=self.card, authorization=self.authorization
+            ).exists()
+        )
+
+    def test_remove_authorization(self):
+        """Can remove an authorization from a combatant."""
+        self.client.force_authenticate(user=self.user)
+        ca = CombatantAuthorization.objects.create(
+            card=self.card, authorization=self.authorization
+        )
+
+        response = self.client.delete(
+            reverse(
+                "combatant-authorization-detail",
+                kwargs={"discipline": "test-combat", "uuid": str(ca.uuid)},
+            )
+        )
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertFalse(CombatantAuthorization.objects.filter(pk=ca.pk).exists())

--- a/emol/cards/tests/test_mail.py
+++ b/emol/cards/tests/test_mail.py
@@ -1,0 +1,234 @@
+"""Tests for email sending functions."""
+
+from datetime import timedelta
+from unittest.mock import patch
+
+from django.contrib.contenttypes.models import ContentType
+from django.test import TestCase, override_settings
+
+from cards.mail import (
+    send_card_expiry,
+    send_card_reminder,
+    send_card_url,
+    send_info_update,
+    send_privacy_policy,
+    send_waiver_expiry,
+    send_waiver_reminder,
+)
+from cards.models import Card, Combatant, Discipline, Reminder, UpdateCode, Waiver
+from cards.utility.time import today
+
+
+class SendCardReminderTestCase(TestCase):
+    """Tests for send_card_reminder."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.discipline = Discipline.objects.create(
+            name="Test Combat", slug="test-combat"
+        )
+        self.combatant = Combatant.objects.create(
+            sca_name="Test Fighter",
+            legal_name="Test Legal",
+            email="test@example.com",
+            accepted_privacy_policy=True,
+        )
+        self.card = Card.objects.create(
+            combatant=self.combatant,
+            discipline=self.discipline,
+            date_issued=today(),
+        )
+
+    @override_settings(SEND_EMAIL=False)
+    def test_send_card_reminder_success(self):
+        """send_card_reminder sends email and returns True."""
+        reminder = Reminder.objects.filter(
+            content_type=ContentType.objects.get_for_model(Card),
+            object_id=self.card.id,
+            days_to_expiry=30,
+        ).first()
+
+        result = send_card_reminder(reminder)
+
+        self.assertTrue(result)
+
+    @override_settings(SEND_EMAIL=False)
+    def test_send_card_reminder_with_invalid_reminder_returns_false(self):
+        """send_card_reminder returns False for orphaned reminder."""
+        card_ct = ContentType.objects.get_for_model(Card)
+        orphaned = Reminder.objects.create(
+            content_type=card_ct,
+            object_id=99999,
+            days_to_expiry=30,
+            due_date=today(),
+        )
+
+        result = send_card_reminder(orphaned)
+
+        self.assertFalse(result)
+
+
+class SendCardExpiryTestCase(TestCase):
+    """Tests for send_card_expiry."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.discipline = Discipline.objects.create(
+            name="Test Combat", slug="test-combat"
+        )
+        self.combatant = Combatant.objects.create(
+            sca_name="Test Fighter",
+            legal_name="Test Legal",
+            email="test@example.com",
+            accepted_privacy_policy=True,
+        )
+        self.card = Card.objects.create(
+            combatant=self.combatant,
+            discipline=self.discipline,
+            date_issued=today(),
+        )
+
+    @override_settings(SEND_EMAIL=False)
+    def test_send_card_expiry_success(self):
+        """send_card_expiry sends email and returns True."""
+        reminder = Reminder.objects.filter(
+            content_type=ContentType.objects.get_for_model(Card),
+            object_id=self.card.id,
+            days_to_expiry=0,
+        ).first()
+
+        result = send_card_expiry(reminder)
+
+        self.assertTrue(result)
+
+
+class SendWaiverReminderTestCase(TestCase):
+    """Tests for send_waiver_reminder."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.combatant = Combatant.objects.create(
+            sca_name="Test Fighter",
+            legal_name="Test Legal",
+            email="test@example.com",
+            accepted_privacy_policy=True,
+        )
+        self.waiver = Waiver.objects.create(
+            combatant=self.combatant,
+            date_signed=today(),
+        )
+
+    @override_settings(SEND_EMAIL=False)
+    def test_send_waiver_reminder_success(self):
+        """send_waiver_reminder sends email and returns True."""
+        reminder = Reminder.objects.filter(
+            content_type=ContentType.objects.get_for_model(Waiver),
+            object_id=self.waiver.id,
+            days_to_expiry=30,
+        ).first()
+
+        result = send_waiver_reminder(reminder)
+
+        self.assertTrue(result)
+
+
+class SendWaiverExpiryTestCase(TestCase):
+    """Tests for send_waiver_expiry."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.combatant = Combatant.objects.create(
+            sca_name="Test Fighter",
+            legal_name="Test Legal",
+            email="test@example.com",
+            accepted_privacy_policy=True,
+        )
+        self.waiver = Waiver.objects.create(
+            combatant=self.combatant,
+            date_signed=today(),
+        )
+
+    @override_settings(SEND_EMAIL=False)
+    def test_send_waiver_expiry_success(self):
+        """send_waiver_expiry sends email and returns True."""
+        reminder = Reminder.objects.filter(
+            content_type=ContentType.objects.get_for_model(Waiver),
+            object_id=self.waiver.id,
+            days_to_expiry=0,
+        ).first()
+
+        result = send_waiver_expiry(reminder)
+
+        self.assertTrue(result)
+
+
+class SendInfoUpdateTestCase(TestCase):
+    """Tests for send_info_update."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.combatant = Combatant.objects.create(
+            sca_name="Test Fighter",
+            legal_name="Test Legal",
+            email="test@example.com",
+            accepted_privacy_policy=True,
+        )
+
+    @override_settings(SEND_EMAIL=False)
+    def test_send_info_update_success(self):
+        """send_info_update sends email and returns True."""
+        update_code = UpdateCode.objects.create(combatant=self.combatant)
+
+        result = send_info_update(self.combatant, update_code)
+
+        self.assertTrue(result)
+
+
+class SendCardUrlTestCase(TestCase):
+    """Tests for send_card_url."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.discipline = Discipline.objects.create(
+            name="Test Combat", slug="test-combat"
+        )
+        self.combatant = Combatant.objects.create(
+            sca_name="Test Fighter",
+            legal_name="Test Legal",
+            email="test@example.com",
+            accepted_privacy_policy=True,
+            card_id="TEST123",
+        )
+        self.card = Card.objects.create(
+            combatant=self.combatant,
+            discipline=self.discipline,
+            date_issued=today(),
+        )
+
+    @override_settings(SEND_EMAIL=False, BASE_URL="http://test.example.com")
+    def test_send_card_url_success(self):
+        """send_card_url sends email and returns True."""
+        result = send_card_url(self.combatant)
+
+        self.assertTrue(result)
+
+
+class SendPrivacyPolicyTestCase(TestCase):
+    """Tests for send_privacy_policy."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.combatant = Combatant.objects.create(
+            sca_name="Test Fighter",
+            legal_name="Test Legal",
+            email="test@example.com",
+            accepted_privacy_policy=False,
+        )
+
+    @override_settings(SEND_EMAIL=False, SITE_URL="http://test.example.com")
+    def test_send_privacy_policy_success(self):
+        """send_privacy_policy sends email and returns True."""
+        result = send_privacy_policy(self.combatant)
+
+        self.assertTrue(result)
+

--- a/emol/cards/tests/test_reminders.py
+++ b/emol/cards/tests/test_reminders.py
@@ -1,0 +1,473 @@
+"""Tests for reminder functionality."""
+
+from datetime import timedelta
+from unittest.mock import patch, MagicMock
+
+from django.conf import settings
+from django.contrib.contenttypes.models import ContentType
+from django.core.management import call_command
+from django.test import TestCase, override_settings
+
+from cards.models import (
+    Authorization,
+    Card,
+    Combatant,
+    Discipline,
+    Reminder,
+    Waiver,
+)
+from cards.utility.time import today
+
+
+class ReminderModelTestCase(TestCase):
+    """Tests for the Reminder model."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.discipline = Discipline.objects.create(
+            name="Test Combat", slug="test-combat"
+        )
+        self.authorization = Authorization.objects.create(
+            name="Test Auth", slug="test-auth", discipline=self.discipline
+        )
+        self.combatant = Combatant.objects.create(
+            sca_name="Test Fighter",
+            legal_name="Test Legal",
+            email="test@example.com",
+            accepted_privacy_policy=True,
+        )
+
+    @override_settings(REMINDER_DAYS=[60, 30, 14, 0])
+    def test_create_or_update_reminders_creates_all_reminder_days(self):
+        """Reminders are created for each day in REMINDER_DAYS."""
+        card = Card.objects.create(
+            combatant=self.combatant,
+            discipline=self.discipline,
+            date_issued=today(),
+        )
+
+        reminders = Reminder.objects.filter(
+            content_type=ContentType.objects.get_for_model(Card),
+            object_id=card.id,
+        )
+
+        self.assertEqual(reminders.count(), 4)
+        days = set(reminders.values_list("days_to_expiry", flat=True))
+        self.assertEqual(days, {60, 30, 14, 0})
+
+    @override_settings(REMINDER_DAYS=[60, 30, 14, 0])
+    def test_create_or_update_reminders_calculates_due_dates(self):
+        """Due dates are calculated from expiration date."""
+        card = Card.objects.create(
+            combatant=self.combatant,
+            discipline=self.discipline,
+            date_issued=today(),
+        )
+        expiration = card.expiration_date
+
+        for reminder in Reminder.objects.filter(object_id=card.id):
+            expected_due = expiration - timedelta(days=reminder.days_to_expiry)
+            self.assertEqual(reminder.due_date, expected_due)
+
+    @override_settings(REMINDER_DAYS=[60, 30, 14, 0])
+    def test_create_or_update_reminders_replaces_existing(self):
+        """Updating reminders deletes old ones and creates new."""
+        card = Card.objects.create(
+            combatant=self.combatant,
+            discipline=self.discipline,
+            date_issued=today() - timedelta(days=365),
+        )
+        old_reminder_ids = list(
+            Reminder.objects.filter(object_id=card.id).values_list("id", flat=True)
+        )
+
+        card.date_issued = today()
+        card.save()
+
+        new_reminders = Reminder.objects.filter(object_id=card.id)
+        self.assertEqual(new_reminders.count(), 4)
+        for old_id in old_reminder_ids:
+            self.assertFalse(Reminder.objects.filter(id=old_id).exists())
+
+    def test_should_send_email_returns_false_without_privacy_acceptance(self):
+        """should_send_email returns False if combatant hasn't accepted privacy."""
+        combatant_no_privacy = Combatant.objects.create(
+            sca_name="No Privacy",
+            legal_name="No Privacy Legal",
+            email="noprivacy@example.com",
+            accepted_privacy_policy=False,
+        )
+        card = Card.objects.create(
+            combatant=combatant_no_privacy,
+            discipline=self.discipline,
+            date_issued=today(),
+        )
+        reminder = Reminder.objects.filter(object_id=card.id).first()
+
+        self.assertFalse(reminder.should_send_email)
+
+    def test_should_send_email_returns_true_with_privacy_acceptance(self):
+        """should_send_email returns True if combatant accepted privacy."""
+        card = Card.objects.create(
+            combatant=self.combatant,
+            discipline=self.discipline,
+            date_issued=today(),
+        )
+        reminder = Reminder.objects.filter(object_id=card.id).first()
+
+        self.assertTrue(reminder.should_send_email)
+
+    def test_should_send_email_returns_false_for_orphaned_reminder(self):
+        """should_send_email returns False if content_object is None."""
+        card_ct = ContentType.objects.get_for_model(Card)
+        orphaned = Reminder.objects.create(
+            content_type=card_ct,
+            object_id=99999,
+            days_to_expiry=30,
+            due_date=today(),
+        )
+
+        self.assertFalse(orphaned.should_send_email)
+
+    @patch("cards.models.card.send_card_reminder")
+    def test_send_email_returns_true_on_success(self, mock_send):
+        """send_email returns True when email is sent successfully."""
+        mock_send.return_value = True
+        card = Card.objects.create(
+            combatant=self.combatant,
+            discipline=self.discipline,
+            date_issued=today(),
+        )
+        reminder = Reminder.objects.filter(object_id=card.id, days_to_expiry=30).first()
+
+        result = reminder.send_email()
+
+        self.assertTrue(result)
+        mock_send.assert_called_once()
+
+    @patch("cards.models.card.send_card_reminder")
+    def test_send_email_returns_false_on_failure(self, mock_send):
+        """send_email returns False when email fails."""
+        mock_send.return_value = False
+        card = Card.objects.create(
+            combatant=self.combatant,
+            discipline=self.discipline,
+            date_issued=today(),
+        )
+        reminder = Reminder.objects.filter(object_id=card.id, days_to_expiry=30).first()
+
+        result = reminder.send_email()
+
+        self.assertFalse(result)
+
+    @patch("cards.models.card.send_card_expiry")
+    def test_send_email_calls_expiry_for_zero_days(self, mock_send):
+        """send_email calls send_expiry for 0-day reminders."""
+        mock_send.return_value = True
+        card = Card.objects.create(
+            combatant=self.combatant,
+            discipline=self.discipline,
+            date_issued=today(),
+        )
+        reminder = Reminder.objects.filter(object_id=card.id, days_to_expiry=0).first()
+
+        reminder.send_email()
+
+        mock_send.assert_called_once()
+
+    def test_send_email_returns_false_without_privacy(self):
+        """send_email returns False without calling mailer if no privacy acceptance."""
+        combatant_no_privacy = Combatant.objects.create(
+            sca_name="No Privacy",
+            legal_name="No Privacy Legal",
+            email="noprivacy@example.com",
+            accepted_privacy_policy=False,
+        )
+        card = Card.objects.create(
+            combatant=combatant_no_privacy,
+            discipline=self.discipline,
+            date_issued=today(),
+        )
+        reminder = Reminder.objects.filter(object_id=card.id).first()
+
+        with patch("cards.models.card.send_card_reminder") as mock_send:
+            result = reminder.send_email()
+
+        self.assertFalse(result)
+        mock_send.assert_not_called()
+
+
+class CardReminderSignalTestCase(TestCase):
+    """Tests for Card post_save signal creating reminders."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.discipline = Discipline.objects.create(
+            name="Test Combat", slug="test-combat"
+        )
+        self.combatant = Combatant.objects.create(
+            sca_name="Test Fighter",
+            legal_name="Test Legal",
+            email="test@example.com",
+            accepted_privacy_policy=True,
+        )
+
+    @override_settings(REMINDER_DAYS=[60, 30, 14, 0])
+    def test_card_creation_creates_reminders(self):
+        """Creating a card triggers reminder creation."""
+        card = Card.objects.create(
+            combatant=self.combatant,
+            discipline=self.discipline,
+            date_issued=today(),
+        )
+
+        reminders = Reminder.objects.filter(object_id=card.id)
+        self.assertEqual(reminders.count(), 4)
+
+    @override_settings(REMINDER_DAYS=[60, 30, 14, 0])
+    def test_card_date_change_updates_reminders(self):
+        """Changing date_issued recreates reminders."""
+        card = Card.objects.create(
+            combatant=self.combatant,
+            discipline=self.discipline,
+            date_issued=today() - timedelta(days=100),
+        )
+        old_due_dates = list(
+            Reminder.objects.filter(object_id=card.id).values_list("due_date", flat=True)
+        )
+
+        card.date_issued = today()
+        card.save()
+
+        new_due_dates = list(
+            Reminder.objects.filter(object_id=card.id).values_list("due_date", flat=True)
+        )
+        self.assertNotEqual(old_due_dates, new_due_dates)
+
+    @override_settings(REMINDER_DAYS=[60, 30, 14, 0])
+    def test_card_other_field_change_no_reminder_update(self):
+        """Changing non-date fields doesn't recreate reminders."""
+        card = Card.objects.create(
+            combatant=self.combatant,
+            discipline=self.discipline,
+            date_issued=today(),
+        )
+        old_reminder_ids = set(
+            Reminder.objects.filter(object_id=card.id).values_list("id", flat=True)
+        )
+
+        card.save()
+
+        new_reminder_ids = set(
+            Reminder.objects.filter(object_id=card.id).values_list("id", flat=True)
+        )
+        self.assertEqual(old_reminder_ids, new_reminder_ids)
+
+
+class WaiverReminderSignalTestCase(TestCase):
+    """Tests for Waiver post_save signal creating reminders."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.combatant = Combatant.objects.create(
+            sca_name="Test Fighter",
+            legal_name="Test Legal",
+            email="test@example.com",
+            accepted_privacy_policy=True,
+        )
+
+    @override_settings(REMINDER_DAYS=[60, 30, 14, 0])
+    def test_waiver_creation_creates_reminders(self):
+        """Creating a waiver triggers reminder creation."""
+        waiver = Waiver.objects.create(
+            combatant=self.combatant,
+            date_signed=today(),
+        )
+
+        reminders = Reminder.objects.filter(object_id=waiver.id)
+        self.assertEqual(reminders.count(), 4)
+
+    @override_settings(REMINDER_DAYS=[60, 30, 14, 0])
+    def test_waiver_date_change_updates_reminders(self):
+        """Changing date_signed recreates reminders."""
+        waiver = Waiver.objects.create(
+            combatant=self.combatant,
+            date_signed=today() - timedelta(days=100),
+        )
+        old_due_dates = list(
+            Reminder.objects.filter(object_id=waiver.id).values_list("due_date", flat=True)
+        )
+
+        waiver.date_signed = today()
+        waiver.save()
+
+        new_due_dates = list(
+            Reminder.objects.filter(object_id=waiver.id).values_list("due_date", flat=True)
+        )
+        self.assertNotEqual(old_due_dates, new_due_dates)
+
+
+class SendRemindersEmailFailureTestCase(TestCase):
+    """Tests for send_reminders behavior when emails fail."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.discipline = Discipline.objects.create(
+            name="Test Combat", slug="test-combat"
+        )
+        self.combatant = Combatant.objects.create(
+            sca_name="Test Fighter",
+            legal_name="Test Legal",
+            email="test@example.com",
+            accepted_privacy_policy=True,
+        )
+
+    @override_settings(REMINDER_DAYS=[60, 30, 14, 0])
+    @patch("cards.models.card.send_card_reminder")
+    @patch("cards.models.card.send_card_expiry")
+    def test_reminders_kept_on_email_failure(self, mock_expiry, mock_reminder):
+        """Reminders are kept when email sending fails."""
+        mock_reminder.return_value = False
+        mock_expiry.return_value = False
+        card = Card.objects.create(
+            combatant=self.combatant,
+            discipline=self.discipline,
+            date_issued=today() - timedelta(days=365 * 2 - 30),
+        )
+        card_ct = ContentType.objects.get_for_model(Card)
+        Reminder.objects.filter(
+            content_type=card_ct, object_id=card.id
+        ).update(due_date=today())
+        initial_count = Reminder.objects.filter(
+            content_type=card_ct, object_id=card.id
+        ).count()
+
+        call_command("send_reminders")
+
+        final_count = Reminder.objects.filter(
+            content_type=card_ct, object_id=card.id
+        ).count()
+        self.assertEqual(initial_count, final_count)
+
+    @override_settings(REMINDER_DAYS=[60, 30, 14, 0])
+    @patch("cards.models.card.send_card_reminder")
+    @patch("cards.models.card.send_card_expiry")
+    def test_reminders_deleted_on_email_success(self, mock_expiry, mock_reminder):
+        """Reminders are deleted when email sending succeeds."""
+        mock_reminder.return_value = True
+        mock_expiry.return_value = True
+        card = Card.objects.create(
+            combatant=self.combatant,
+            discipline=self.discipline,
+            date_issued=today() - timedelta(days=365 * 2 - 30),
+        )
+        card_ct = ContentType.objects.get_for_model(Card)
+        Reminder.objects.filter(
+            content_type=card_ct, object_id=card.id
+        ).update(due_date=today())
+
+        call_command("send_reminders")
+
+        final_count = Reminder.objects.filter(
+            content_type=card_ct, object_id=card.id
+        ).count()
+        self.assertEqual(final_count, 0)
+
+
+class ReminderHygieneCommandTestCase(TestCase):
+    """Tests for the reminder_hygiene management command."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.discipline = Discipline.objects.create(
+            name="Test Combat", slug="test-combat"
+        )
+        self.combatant = Combatant.objects.create(
+            sca_name="Test Fighter",
+            legal_name="Test Legal",
+            email="test@example.com",
+            accepted_privacy_policy=True,
+        )
+
+    @override_settings(REMINDER_DAYS=[60, 30, 14, 0])
+    def test_hygiene_reports_missing_reminders(self):
+        """Hygiene command reports cards with missing reminders."""
+        card = Card.objects.create(
+            combatant=self.combatant,
+            discipline=self.discipline,
+            date_issued=today(),
+        )
+        Reminder.objects.filter(object_id=card.id).delete()
+
+        call_command("reminder_hygiene")
+
+    @override_settings(REMINDER_DAYS=[60, 30, 14, 0])
+    def test_hygiene_fix_creates_missing_reminders(self):
+        """Hygiene command with --fix creates missing reminders."""
+        card = Card.objects.create(
+            combatant=self.combatant,
+            discipline=self.discipline,
+            date_issued=today(),
+        )
+        Reminder.objects.filter(object_id=card.id).delete()
+        self.assertEqual(Reminder.objects.filter(object_id=card.id).count(), 0)
+
+        call_command("reminder_hygiene", "--fix")
+
+        self.assertEqual(Reminder.objects.filter(object_id=card.id).count(), 4)
+
+    @override_settings(REMINDER_DAYS=[60, 30, 14, 0])
+    def test_hygiene_reports_orphaned_reminders(self):
+        """Hygiene command reports orphaned reminders."""
+        card_ct = ContentType.objects.get_for_model(Card)
+        Reminder.objects.create(
+            content_type=card_ct,
+            object_id=99999,
+            days_to_expiry=30,
+            due_date=today(),
+        )
+
+        call_command("reminder_hygiene")
+
+    @override_settings(REMINDER_DAYS=[60, 30, 14, 0])
+    def test_hygiene_no_issues_with_healthy_data(self):
+        """Hygiene command reports no issues when data is healthy."""
+        Card.objects.create(
+            combatant=self.combatant,
+            discipline=self.discipline,
+            date_issued=today(),
+        )
+
+        call_command("reminder_hygiene")
+
+    @override_settings(REMINDER_DAYS=[60, 30, 14, 0])
+    def test_hygiene_ignores_expired_cards(self):
+        """Hygiene command ignores expired cards."""
+        expired_card = Card.objects.create(
+            combatant=self.combatant,
+            discipline=self.discipline,
+            date_issued=today() - timedelta(days=365 * 3),
+        )
+        Reminder.objects.filter(object_id=expired_card.id).delete()
+
+        call_command("reminder_hygiene", "--fix")
+
+        self.assertEqual(Reminder.objects.filter(object_id=expired_card.id).count(), 0)
+
+    @override_settings(REMINDER_DAYS=[60, 30, 14, 0])
+    def test_hygiene_checks_waivers(self):
+        """Hygiene command checks waivers too."""
+        waiver = Waiver.objects.create(
+            combatant=self.combatant,
+            date_signed=today(),
+        )
+        Reminder.objects.filter(object_id=waiver.id).delete()
+
+        call_command("reminder_hygiene", "--fix")
+
+        waiver_ct = ContentType.objects.get_for_model(Waiver)
+        waiver_reminders = Reminder.objects.filter(
+            content_type=waiver_ct, object_id=waiver.id
+        )
+        self.assertEqual(waiver_reminders.count(), 4)
+

--- a/emol/cards/tests/test_views_privacy.py
+++ b/emol/cards/tests/test_views_privacy.py
@@ -1,0 +1,67 @@
+"""Tests for privacy-related views."""
+
+from django.test import TestCase, override_settings
+from django.urls import reverse
+
+from cards.models import Combatant, PrivacyPolicy
+
+
+class PrivacyPolicyViewTestCase(TestCase):
+    """Tests for the privacy policy view."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        PrivacyPolicy.objects.create(text="# Test Privacy Policy\n\nThis is a test.")
+        self.combatant = Combatant.objects.create(
+            sca_name="Test Fighter",
+            legal_name="Test Legal",
+            email="test@example.com",
+            accepted_privacy_policy=False,
+        )
+
+    def test_privacy_policy_get_without_code(self):
+        """GET request without code shows policy."""
+        response = self.client.get(reverse("privacy-policy"))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Test Privacy Policy")
+
+    def test_privacy_policy_get_with_valid_code(self):
+        """GET request with valid code shows policy with accept form."""
+        code = self.combatant.privacy_acceptance_code
+        response = self.client.get(
+            reverse("privacy-policy", kwargs={"code": code})
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Test Privacy Policy")
+
+    def test_privacy_policy_get_with_invalid_code(self):
+        """GET request with invalid code returns 404."""
+        response = self.client.get(
+            reverse("privacy-policy", kwargs={"code": "invalid"})
+        )
+        self.assertEqual(response.status_code, 404)
+
+    @override_settings(SEND_EMAIL=False, SITE_URL="http://test.example.com")
+    def test_privacy_policy_accept(self):
+        """POST with accept updates combatant and shows accepted page."""
+        code = self.combatant.privacy_acceptance_code
+        response = self.client.post(
+            reverse("privacy-policy", kwargs={"code": code}),
+            {"code": code, "accept": "1"},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "privacy/privacy_accepted.html")
+        self.combatant.refresh_from_db()
+        self.assertTrue(self.combatant.accepted_privacy_policy)
+
+    def test_privacy_policy_decline(self):
+        """POST with decline deletes combatant."""
+        code = self.combatant.privacy_acceptance_code
+        combatant_id = self.combatant.id
+        response = self.client.post(
+            reverse("privacy-policy", kwargs={"code": code}),
+            {"code": code, "decline": "1"},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "privacy/privacy_declined.html")
+        self.assertFalse(Combatant.objects.filter(id=combatant_id).exists())

--- a/emol/emailer/tests.py
+++ b/emol/emailer/tests.py
@@ -1,0 +1,105 @@
+"""Tests for the AWSEmailer class."""
+
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase, override_settings
+
+from emailer import AWSEmailer
+
+
+class AWSEmailerTestCase(TestCase):
+    """Tests for AWSEmailer.send_email()."""
+
+    @override_settings(SEND_EMAIL=False)
+    def test_send_email_disabled_returns_true(self):
+        """When SEND_EMAIL is False, emails are logged but not sent."""
+        result = AWSEmailer.send_email(
+            recipient="test@example.com",
+            subject="Test Subject",
+            body="Test body",
+        )
+
+        self.assertTrue(result)
+
+    @override_settings(
+        SEND_EMAIL=True,
+        MAIL_DEFAULT_SENDER="sender@example.com",
+        MOL_EMAIL="mol@example.com",
+    )
+    @patch("emailer.get_aws_session")
+    def test_send_email_success(self, mock_get_session):
+        """Successful email send returns True."""
+        mock_client = MagicMock()
+        mock_client.send_email.return_value = {"MessageId": "test-id"}
+        mock_session = MagicMock()
+        mock_session.client.return_value = mock_client
+        mock_get_session.return_value = mock_session
+
+        result = AWSEmailer.send_email(
+            recipient="test@example.com",
+            subject="Test Subject",
+            body="Test body",
+        )
+
+        self.assertTrue(result)
+        mock_client.send_email.assert_called_once()
+        call_args = mock_client.send_email.call_args
+        self.assertEqual(
+            call_args.kwargs["Destination"]["ToAddresses"], ["test@example.com"]
+        )
+        self.assertEqual(
+            call_args.kwargs["Message"]["Subject"]["Data"], "Test Subject"
+        )
+
+    @override_settings(
+        SEND_EMAIL=True,
+        MAIL_DEFAULT_SENDER="sender@example.com",
+        MOL_EMAIL="mol@example.com",
+    )
+    @patch("emailer.get_aws_session")
+    def test_send_email_with_custom_from_and_reply_to(self, mock_get_session):
+        """Custom from_email and reply_to are used when provided."""
+        mock_client = MagicMock()
+        mock_client.send_email.return_value = {"MessageId": "test-id"}
+        mock_session = MagicMock()
+        mock_session.client.return_value = mock_client
+        mock_get_session.return_value = mock_session
+
+        AWSEmailer.send_email(
+            recipient="test@example.com",
+            subject="Test",
+            body="Body",
+            from_email="custom@example.com",
+            reply_to="reply@example.com",
+        )
+
+        call_args = mock_client.send_email.call_args
+        self.assertIn("custom@example.com", call_args.kwargs["Source"])
+        self.assertEqual(call_args.kwargs["ReplyToAddresses"], ["reply@example.com"])
+
+    @override_settings(
+        SEND_EMAIL=True,
+        MAIL_DEFAULT_SENDER="sender@example.com",
+        MOL_EMAIL="mol@example.com",
+    )
+    @patch("emailer.get_aws_session")
+    def test_send_email_ses_error_returns_false(self, mock_get_session):
+        """SES client error returns False."""
+        from botocore.exceptions import ClientError
+
+        mock_client = MagicMock()
+        mock_client.send_email.side_effect = ClientError(
+            {"Error": {"Code": "TestError", "Message": "Test"}}, "send_email"
+        )
+        mock_session = MagicMock()
+        mock_session.client.return_value = mock_client
+        mock_get_session.return_value = mock_session
+
+        result = AWSEmailer.send_email(
+            recipient="test@example.com",
+            subject="Test",
+            body="Body",
+        )
+
+        self.assertFalse(result)
+

--- a/emol/sso_user/decorators.py
+++ b/emol/sso_user/decorators.py
@@ -26,7 +26,7 @@ def login_required(handler_method):
         if not get_current_user():
             # Short-circuit anonymous API invocations
             if "emol.api" in args[0].__module__:
-                return HttpResponse(401)
+                return HttpResponse(status=401)
 
             return HttpResponseRedirect(reverse(views.oauth_login))
 
@@ -51,11 +51,11 @@ def admin_required(handler_method):
         """Perform the check."""
         user = get_current_user()
         if user is None:
-            return HttpResponse(401)
+            return HttpResponse(status=401)
 
-        if user.is_admin:
+        if user.is_superuser:
             return handler_method(*args, **kwargs)
 
-        return HttpResponse(401)
+        return HttpResponse(status=401)
 
     return check_admin

--- a/emol/sso_user/tests.py
+++ b/emol/sso_user/tests.py
@@ -1,22 +1,35 @@
-# tests.py
+"""Tests for sso_user app."""
+
+from io import StringIO
+from unittest.mock import MagicMock, patch
+
 from django.contrib.auth import get_user_model
-from django.test import Client, TestCase
+from django.contrib.auth.models import AnonymousUser
+from django.core.management import call_command
+from django.http import HttpResponse
+from django.test import Client, RequestFactory, TestCase, override_settings
 from django.urls import reverse
 
+from .decorators import admin_required, login_required
 from .google_oauth import GoogleOAuth
 from .models import SSOUser
 
 
 class SSOUserModelTest(TestCase):
+    """Tests for the SSOUser model."""
+
     def setUp(self):
+        """Set up test fixtures."""
         self.user = SSOUser.objects.create(email="test@example.com")
 
     def test_user_creation(self):
+        """Test basic user creation."""
         self.assertEqual(self.user.email, "test@example.com")
         self.assertFalse(self.user.is_superuser)
         self.assertFalse(self.user.is_staff)
 
     def test_user_manager(self):
+        """Test user manager create methods."""
         user = SSOUser.objects.create_user(email="user@example.com")
         self.assertFalse(user.is_superuser)
         self.assertFalse(user.is_staff)
@@ -61,17 +74,155 @@ class OAuthViewsTest(TestCase):
 
 
 class AdminOAuthViewTest(TestCase):
+    """Tests for admin OAuth views."""
+
     def setUp(self):
+        """Set up test fixtures."""
         self.client = Client()
 
     def test_admin_oauth(self):
+        """Test admin OAuth redirect."""
         response = self.client.get(reverse("admin_oauth"))
         self.assertEqual(response.status_code, 302)
-        # In development/test mode, redirects to mock callback
-        # In production, would redirect to Google OAuth
         if hasattr(response, 'url') and response.url:
             self.assertTrue(
                 "https://accounts.google.com/o/oauth2/v2/auth" in response.url or
                 "/auth/mock_oauth_callback/" in response.url,
                 f"Unexpected redirect URL: {response.url}"
             )
+
+
+class LoginRequiredDecoratorTestCase(TestCase):
+    """Tests for the login_required decorator."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.factory = RequestFactory()
+        self.user = SSOUser.objects.create_user(email="test@example.com")
+
+    def test_login_required_allows_authenticated_user(self):
+        """Authenticated user can access decorated view."""
+        @login_required
+        def test_view(request):
+            return HttpResponse("OK")
+
+        request = self.factory.get("/test/")
+        request.user = self.user
+
+        with patch("sso_user.decorators.get_current_user", return_value=self.user):
+            response = test_view(request)
+
+        self.assertEqual(response.status_code, 200)
+
+    def test_login_required_redirects_anonymous_user(self):
+        """Anonymous user is redirected to login."""
+        @login_required
+        def test_view(request):
+            return HttpResponse("OK")
+
+        request = self.factory.get("/test/")
+        request.user = AnonymousUser()
+
+        with patch("sso_user.decorators.get_current_user", return_value=None):
+            response = test_view(request)
+
+        self.assertEqual(response.status_code, 302)
+
+
+class AdminRequiredDecoratorTestCase(TestCase):
+    """Tests for the admin_required decorator."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.factory = RequestFactory()
+        self.admin = SSOUser.objects.create_superuser(email="admin@example.com")
+        self.user = SSOUser.objects.create_user(email="user@example.com")
+
+    def test_admin_required_allows_superuser(self):
+        """Superuser can access decorated view."""
+        @admin_required
+        def test_view(request):
+            return HttpResponse("OK")
+
+        request = self.factory.get("/test/")
+        request.user = self.admin
+
+        with patch("sso_user.decorators.get_current_user", return_value=self.admin):
+            response = test_view(request)
+
+        self.assertEqual(response.status_code, 200)
+
+    def test_admin_required_denies_regular_user(self):
+        """Regular user is denied access."""
+        @admin_required
+        def test_view(request):
+            return HttpResponse("OK")
+
+        request = self.factory.get("/test/")
+        request.user = self.user
+
+        with patch("sso_user.decorators.get_current_user", return_value=self.user):
+            response = test_view(request)
+
+        self.assertEqual(response.status_code, 401)
+
+    def test_admin_required_denies_anonymous(self):
+        """Anonymous user is denied access."""
+        @admin_required
+        def test_view(request):
+            return HttpResponse("OK")
+
+        request = self.factory.get("/test/")
+        request.user = AnonymousUser()
+
+        with patch("sso_user.decorators.get_current_user", return_value=None):
+            response = test_view(request)
+
+        self.assertEqual(response.status_code, 401)
+
+
+class EnsureSuperuserCommandTestCase(TestCase):
+    """Tests for the ensure_superuser management command."""
+
+    def test_does_nothing_if_superuser_exists(self):
+        """Command exits early if superuser already exists."""
+        SSOUser.objects.create_superuser(email="existing@example.com")
+        out = StringIO()
+
+        call_command("ensure_superuser", stdout=out)
+
+        self.assertIn("already exists", out.getvalue())
+
+    @override_settings(EMOL_DEV=True)
+    def test_creates_superuser_with_email_argument(self):
+        """Command creates superuser with provided email."""
+        out = StringIO()
+
+        call_command(
+            "ensure_superuser",
+            email="new@example.com",
+            non_interactive=True,
+            stdout=out,
+        )
+
+        self.assertTrue(SSOUser.objects.filter(email="new@example.com").exists())
+        user = SSOUser.objects.get(email="new@example.com")
+        self.assertTrue(user.is_superuser)
+
+    @patch.dict("os.environ", {"SUPERUSER_EMAIL": "env@example.com"})
+    def test_creates_superuser_from_env_var(self):
+        """Command uses SUPERUSER_EMAIL environment variable."""
+        out = StringIO()
+
+        call_command("ensure_superuser", non_interactive=True, stdout=out)
+
+        self.assertTrue(SSOUser.objects.filter(email="env@example.com").exists())
+
+    @patch.dict("os.environ", {"EMOL_DEV": "1"})
+    def test_uses_default_email_in_dev_mode(self):
+        """Command uses default email in EMOL_DEV mode."""
+        out = StringIO()
+
+        call_command("ensure_superuser", non_interactive=True, stdout=out)
+
+        self.assertTrue(SSOUser.objects.filter(email="admin@emol.com").exists())


### PR DESCRIPTION
- Add test_api.py for cards API endpoints
- Add test_mail.py for email functionality
- Add test_reminders.py for reminder system
- Add test_views_privacy.py for privacy-related views
- Add emailer/tests.py for emailer module
- Expand sso_user/tests.py coverage