### PR TITLE
fix: tighten cards permissions and reminder cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,6 +102,12 @@ test: ## Run tests in container
 	@docker exec $(APP_CONTAINER) echo "OK" >/dev/null 2>&1 || (echo "Starting containers..." && docker compose up -d && sleep 10)
 	docker exec -it $(APP_CONTAINER) poetry run python manage.py test
 
+rebuild-test: ## Rebuild app container and run tests
+	docker compose stop app
+	docker compose build app
+	docker compose up -d app --wait
+	docker exec $(APP_CONTAINER) poetry run python manage.py test
+
 # =============================================================================
 # Environment Setup
 # =============================================================================

--- a/emol/cards/api/permissions.py
+++ b/emol/cards/api/permissions.py
@@ -7,18 +7,21 @@ from rest_framework import permissions
 class CombatantInfoPermission(permissions.BasePermission):
     """Check if user can read or write combatant info"""
 
-    def has_object_permission(self, request, view, obj):
+    READ_PERMISSION = "read_combatant_info"
+    WRITE_PERMISSION = "write_combatant_info"
+
+    def has_permission(self, request, view):
         if request.method in permissions.SAFE_METHODS:
             return UserPermission.user_has_permission(
-                request.user, CombatantInfoPermission.READ_PERMISSION
+                request.user, self.READ_PERMISSION
             )
 
         return UserPermission.user_has_permission(
-            request.user, CombatantInfoPermission.WRITE_PERMISSION
+            request.user, self.WRITE_PERMISSION
         )
 
-    READ_PERMISSION = "read_combatant_info"
-    WRITE_PERMISSION = "write_combatant_info"
+    def has_object_permission(self, request, view, obj):
+        return self.has_permission(request, view)
 
 
 class CombatantAuthorizationPermission(permissions.BasePermission):
@@ -63,9 +66,6 @@ class WaiverDatePermission(permissions.BasePermission):
     """Check if user can read or write waiver date"""
 
     def has_permission(self, request, view):
-        if request.method in permissions.SAFE_METHODS:
-            return True
-
         return UserPermission.user_has_permission(
             request.user, WaiverDatePermission.WRITE_PERMISSION
         )
@@ -78,7 +78,9 @@ class CardDatePermission(permissions.BasePermission):
 
     def has_permission(self, request, view):
         if request.method in permissions.SAFE_METHODS:
-            return True
+            return UserPermission.user_has_permission(
+                request.user, CardDatePermission.WRITE_PERMISSION
+            )
 
         data = request.data
         discipline_slug = data.get("discipline_slug")
@@ -89,3 +91,12 @@ class CardDatePermission(permissions.BasePermission):
         )
 
     WRITE_PERMISSION = "write_card_date"
+
+
+class ResendPrivacyPermission(permissions.BasePermission):
+    """Allow resending privacy policy email for users who can read combatant info"""
+
+    def has_permission(self, request, view):
+        return UserPermission.user_has_permission(
+            request.user, CombatantInfoPermission.READ_PERMISSION
+        )

--- a/emol/cards/api/privacy.py
+++ b/emol/cards/api/privacy.py
@@ -7,6 +7,8 @@ from rest_framework import serializers, status
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from .permissions import ResendPrivacyPermission
+
 logger = logging.getLogger("cards")
 
 
@@ -18,6 +20,8 @@ class ResendPrivacyView(APIView):
     """
     API endpoint for resending the privacy policy email to a combatant.
     """
+
+    permission_classes = [ResendPrivacyPermission]
 
     def post(self, request):
         """

--- a/emol/cards/management/commands/send_reminders.py
+++ b/emol/cards/management/commands/send_reminders.py
@@ -2,7 +2,7 @@ import logging
 from datetime import date
 
 from cards.models.reminder import Reminder
-from cards.utility.time import DATE_FORMAT
+from cards.utility.time import DATE_FORMAT, today
 from django.core.management.base import BaseCommand
 from django.utils import timezone
 
@@ -42,7 +42,9 @@ class Command(BaseCommand):
                 logger.info(f"Deleted {count} orphaned reminders.")
 
         # 2. Process DUE reminders
-        due_reminders = Reminder.objects.filter(due_date__lte=now)
+        # Compare against today's date using the same helper used to set due_date
+        current_date = today()
+        due_reminders = Reminder.objects.filter(due_date__lte=current_date)
         due_count = due_reminders.count()
 
         logger.info(

--- a/emol/cards/tests/test_permissions.py
+++ b/emol/cards/tests/test_permissions.py
@@ -1,0 +1,192 @@
+"""Tests for DRF permission classes in cards.api.permissions."""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from cards.api.permissions import (
+    CardDatePermission,
+    CombatantAuthorizationPermission,
+    CombatantInfoPermission,
+    CombatantMarshalPermission,
+    ResendPrivacyPermission,
+    WaiverDatePermission,
+)
+from sso_user.models import SSOUser
+
+
+class BasePermissionTestCase(TestCase):
+    """Base helpers for permission tests."""
+
+    def setUp(self):
+        self.user = SSOUser.objects.create_user(email="perm-test@example.com")
+
+    def make_request(self, method: str, data=None):
+        return SimpleNamespace(method=method.upper(), data=data or {}, user=self.user)
+
+
+class CombatantInfoPermissionTests(BasePermissionTestCase):
+    def setUp(self):
+        super().setUp()
+        self.permission = CombatantInfoPermission()
+
+    @patch("cards.api.permissions.UserPermission.user_has_permission")
+    def test_read_requires_read_combatant_info(self, mock_has_perm):
+        request = self.make_request("GET")
+        mock_has_perm.return_value = True
+
+        self.assertTrue(self.permission.has_permission(request, view=object()))
+        mock_has_perm.assert_called_with(self.user, "read_combatant_info")
+
+        mock_has_perm.reset_mock()
+        mock_has_perm.return_value = False
+        self.assertFalse(self.permission.has_permission(request, view=object()))
+        mock_has_perm.assert_called_with(self.user, "read_combatant_info")
+
+    @patch("cards.api.permissions.UserPermission.user_has_permission")
+    def test_write_requires_write_combatant_info(self, mock_has_perm):
+        request = self.make_request("PATCH", data={"legal_name": "Updated"})
+        mock_has_perm.return_value = True
+
+        self.assertTrue(self.permission.has_permission(request, view=object()))
+        mock_has_perm.assert_called_with(self.user, "write_combatant_info")
+
+        mock_has_perm.reset_mock()
+        mock_has_perm.return_value = False
+        self.assertFalse(self.permission.has_permission(request, view=object()))
+        mock_has_perm.assert_called_with(self.user, "write_combatant_info")
+
+
+class WaiverDatePermissionTests(BasePermissionTestCase):
+    def setUp(self):
+        super().setUp()
+        self.permission = WaiverDatePermission()
+
+    @patch("cards.api.permissions.UserPermission.user_has_permission")
+    def test_waiver_permission_required_for_read_and_write(self, mock_has_perm):
+        mock_has_perm.return_value = True
+
+        # GET
+        request = self.make_request("GET")
+        self.assertTrue(self.permission.has_permission(request, view=object()))
+        mock_has_perm.assert_called_with(self.user, "write_waiver_date")
+
+        mock_has_perm.reset_mock()
+
+        # PUT
+        request = self.make_request("PUT", data={"date_signed": "2024-01-01"})
+        self.assertTrue(self.permission.has_permission(request, view=object()))
+        mock_has_perm.assert_called_with(self.user, "write_waiver_date")
+
+        # Denied when underlying permission check fails
+        mock_has_perm.reset_mock()
+        mock_has_perm.return_value = False
+        request = self.make_request("GET")
+        self.assertFalse(self.permission.has_permission(request, view=object()))
+        mock_has_perm.assert_called_with(self.user, "write_waiver_date")
+
+
+class CardDatePermissionTests(BasePermissionTestCase):
+    def setUp(self):
+        super().setUp()
+        self.permission = CardDatePermission()
+
+    @patch("cards.api.permissions.UserPermission.user_has_permission")
+    def test_card_date_requires_permission_for_given_discipline(self, mock_has_perm):
+        data = {
+            "uuid": "00000000-0000-0000-0000-000000000000",
+            "discipline_slug": "test",
+            "date_issued": "2024-01-01",
+        }
+        request = self.make_request("PUT", data=data)
+        mock_has_perm.return_value = True
+
+        self.assertTrue(self.permission.has_permission(request, view=object()))
+        mock_has_perm.assert_called_with(self.user, "write_card_date", "test")
+
+        mock_has_perm.reset_mock()
+        mock_has_perm.return_value = False
+        self.assertFalse(self.permission.has_permission(request, view=object()))
+        mock_has_perm.assert_called_with(self.user, "write_card_date", "test")
+
+    @patch("cards.api.permissions.UserPermission.user_has_permission")
+    def test_card_date_denied_when_discipline_missing(self, mock_has_perm):
+        data = {
+            "uuid": "00000000-0000-0000-0000-000000000000",
+            # missing discipline_slug
+            "date_issued": "2024-01-01",
+        }
+        request = self.make_request("PUT", data=data)
+        self.assertFalse(self.permission.has_permission(request, view=object()))
+        mock_has_perm.assert_not_called()
+
+
+class AuthorizationMarshalPermissionTests(BasePermissionTestCase):
+    def setUp(self):
+        super().setUp()
+
+    @patch("cards.api.permissions.UserPermission.user_has_permission")
+    def test_combatant_authorization_permission_requires_discipline_permission(
+        self, mock_has_perm
+    ):
+        permission = CombatantAuthorizationPermission()
+
+        class DummyView:
+            kwargs = {"discipline": "sword"}
+
+        request = self.make_request("POST")
+        mock_has_perm.return_value = True
+
+        self.assertTrue(permission.has_permission(request, view=DummyView()))
+        mock_has_perm.assert_called_with(
+            self.user, "write_authorizations", "sword"
+        )
+
+        mock_has_perm.reset_mock()
+        mock_has_perm.return_value = False
+        self.assertFalse(permission.has_permission(request, view=DummyView()))
+        mock_has_perm.assert_called_with(
+            self.user, "write_authorizations", "sword"
+        )
+
+    @patch("cards.api.permissions.UserPermission.user_has_permission")
+    def test_combatant_marshal_permission_requires_discipline_permission(
+        self, mock_has_perm
+    ):
+        permission = CombatantMarshalPermission()
+
+        class DummyView:
+            kwargs = {"discipline": "sword"}
+
+        request = self.make_request("POST")
+        mock_has_perm.return_value = True
+
+        self.assertTrue(permission.has_permission(request, view=DummyView()))
+        mock_has_perm.assert_called_with(self.user, "write_marshal", "sword")
+
+        mock_has_perm.reset_mock()
+        mock_has_perm.return_value = False
+        self.assertFalse(permission.has_permission(request, view=DummyView()))
+        mock_has_perm.assert_called_with(self.user, "write_marshal", "sword")
+
+
+class ResendPrivacyPermissionTests(BasePermissionTestCase):
+    def setUp(self):
+        super().setUp()
+        self.permission = ResendPrivacyPermission()
+
+    @patch("cards.api.permissions.UserPermission.user_has_permission")
+    def test_resend_privacy_requires_read_combatant_info(self, mock_has_perm):
+        request = self.make_request("POST", data={})
+        mock_has_perm.return_value = True
+
+        self.assertTrue(self.permission.has_permission(request, view=object()))
+        mock_has_perm.assert_called_with(self.user, "read_combatant_info")
+
+        mock_has_perm.reset_mock()
+        mock_has_perm.return_value = False
+        self.assertFalse(self.permission.has_permission(request, view=object()))
+        mock_has_perm.assert_called_with(self.user, "read_combatant_info")
+
+


### PR DESCRIPTION
- enforce UserPermission checks in combatant, waiver, card-date, and resend-privacy APIs
- add unit tests for cards.api.permissions to cover permission slugs and discipline handling
- fix send_reminders to filter
- add a `rebuild-test` make target for easy down + build + up + test